### PR TITLE
Align last known good time commit / revert to shadow fail-safe approach

### DIFF
--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -338,11 +338,6 @@ void FailSafeCleanup(const chip::DeviceLayer::ChipDeviceEvent * event)
         {
             ChipLogError(Zcl, "OpCreds: failed to delete fabric at index %u: %" CHIP_ERROR_FORMAT, fabricIndex, err.Format());
         }
-        err = Server::GetInstance().GetFabricTable().RevertLastKnownGoodChipEpochTime();
-        if (err != CHIP_NO_ERROR)
-        {
-            ChipLogError(Zcl, "OpCreds: failed to revert Last Known Good Time: %" CHIP_ERROR_FORMAT, err.Format());
-        }
     }
 
     // If an UpdateNOC command had been successfully invoked, revert the state of operational key pair, NOC and ICAC for that
@@ -351,11 +346,6 @@ void FailSafeCleanup(const chip::DeviceLayer::ChipDeviceEvent * event)
     if (event->FailSafeTimerExpired.updateNocCommandHasBeenInvoked)
     {
         // TODO: Revert the state of operational key pair, NOC and ICAC
-        CHIP_ERROR err = Server::GetInstance().GetFabricTable().RevertLastKnownGoodChipEpochTime();
-        if (err != CHIP_NO_ERROR)
-        {
-            ChipLogError(Zcl, "OpCreds: failed to revert Last Known Good Time: %" CHIP_ERROR_FORMAT, err.Format());
-        }
     }
 }
 

--- a/src/credentials/FabricTable.h
+++ b/src/credentials/FabricTable.h
@@ -410,22 +410,6 @@ public:
      */
     CHIP_ERROR SetLastKnownGoodChipEpochTime(System::Clock::Seconds32 lastKnownGoodChipEpochTime);
 
-    /*
-     * Commit the Last Known Good Time by deleting the fail-safe backup from
-     * storage.
-     *
-     * @return CHIP_NO_ERROR on success, else an appopriate CHIP_ERROR
-     */
-    CHIP_ERROR CommitLastKnownGoodChipEpochTime() { return mLastKnownGoodTime.CommitLastKnownGoodChipEpochTime(); }
-
-    /*
-     * Revert the Last Known Good Time to the fail-safe backup value in
-     * persistence if any exists.
-     *
-     * @return CHIP_NO_ERROR on success, else an appopriate CHIP_ERROR
-     */
-    CHIP_ERROR RevertLastKnownGoodChipEpochTime() { return mLastKnownGoodTime.RevertLastKnownGoodChipEpochTime(); }
-
     uint8_t FabricCount() const { return mFabricCount; }
 
     ConstFabricIterator cbegin() const { return ConstFabricIterator(mStates, 0, CHIP_CONFIG_MAX_FABRICS); }
@@ -748,8 +732,6 @@ private:
     FabricIndex mFabricIndexWithPendingState = kUndefinedFabricIndex;
 
     LastKnownGoodTime mLastKnownGoodTime;
-    // Pneding last known good time gathered from the last pending cert operations
-    System::Clock::Seconds32 mPendingLastKnownGoodTime;
 
     // We may not have an mNextAvailableFabricIndex if our table is as large as
     // it can go and is full.

--- a/src/credentials/LastKnownGoodTime.cpp
+++ b/src/credentials/LastKnownGoodTime.cpp
@@ -30,8 +30,7 @@ namespace chip {
 
 namespace {
 // Tags for Last Known Good Time.
-constexpr TLV::Tag kLastKnownGoodChipEpochSecondsTag         = TLV::ContextTag(0);
-constexpr TLV::Tag kFailSafeLastKnownGoodChipEpochSecondsTag = TLV::ContextTag(1);
+constexpr TLV::Tag kLastKnownGoodChipEpochSecondsTag = TLV::ContextTag(0);
 } // anonymous namespace
 
 void LastKnownGoodTime::LogTime(const char * msg, System::Clock::Seconds32 chipEpochTime)
@@ -48,8 +47,7 @@ void LastKnownGoodTime::LogTime(const char * msg, System::Clock::Seconds32 chipE
     ChipLogProgress(TimeService, "%s%s", msg, buf);
 }
 
-CHIP_ERROR LastKnownGoodTime::LoadLastKnownGoodChipEpochTime(System::Clock::Seconds32 & lastKnownGoodChipEpochTime,
-                                                             Optional<System::Clock::Seconds32> & failSafeBackup) const
+CHIP_ERROR LastKnownGoodTime::LoadLastKnownGoodChipEpochTime(System::Clock::Seconds32 & lastKnownGoodChipEpochTime) const
 {
     uint8_t buf[LastKnownGoodTimeTLVMaxSize()];
     uint16_t size = sizeof(buf);
@@ -64,26 +62,10 @@ CHIP_ERROR LastKnownGoodTime::LoadLastKnownGoodChipEpochTime(System::Clock::Seco
     ReturnErrorOnFailure(reader.Next(kLastKnownGoodChipEpochSecondsTag));
     ReturnErrorOnFailure(reader.Get(seconds));
     lastKnownGoodChipEpochTime = System::Clock::Seconds32(seconds);
-    CHIP_ERROR err             = reader.Next();
-    if (err == CHIP_END_OF_TLV)
-    {
-        failSafeBackup = NullOptional;
-        return CHIP_NO_ERROR; // not an error; this tag is optional
-    }
-    VerifyOrReturnError(reader.GetTag() == kFailSafeLastKnownGoodChipEpochSecondsTag, CHIP_ERROR_UNEXPECTED_TLV_ELEMENT);
-    ReturnErrorOnFailure(reader.Get(seconds));
-    failSafeBackup.Emplace(seconds);
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR LastKnownGoodTime::LoadLastKnownGoodChipEpochTime(System::Clock::Seconds32 & lastKnownGoodChipEpochTime) const
-{
-    Optional<System::Clock::Seconds32> failSafeBackup;
-    return LoadLastKnownGoodChipEpochTime(lastKnownGoodChipEpochTime, failSafeBackup);
-}
-
-CHIP_ERROR LastKnownGoodTime::StoreLastKnownGoodChipEpochTime(System::Clock::Seconds32 lastKnownGoodChipEpochTime,
-                                                              const Optional<System::Clock::Seconds32> & failSafeBackup) const
+CHIP_ERROR LastKnownGoodTime::StoreLastKnownGoodChipEpochTime(System::Clock::Seconds32 lastKnownGoodChipEpochTime) const
 {
     uint8_t buf[LastKnownGoodTimeTLVMaxSize()];
     TLV::TLVWriter writer;
@@ -91,21 +73,12 @@ CHIP_ERROR LastKnownGoodTime::StoreLastKnownGoodChipEpochTime(System::Clock::Sec
     TLV::TLVType outerType;
     ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, outerType));
     ReturnErrorOnFailure(writer.Put(kLastKnownGoodChipEpochSecondsTag, lastKnownGoodChipEpochTime.count()));
-    if (failSafeBackup.HasValue())
-    {
-        ReturnErrorOnFailure(writer.Put(kFailSafeLastKnownGoodChipEpochSecondsTag, failSafeBackup.Value().count()));
-    }
     ReturnErrorOnFailure(writer.EndContainer(outerType));
     const auto length = writer.GetLengthWritten();
     VerifyOrReturnError(CanCastTo<uint16_t>(length), CHIP_ERROR_BUFFER_TOO_SMALL);
     DefaultStorageKeyAllocator keyAlloc;
     ReturnErrorOnFailure(mStorage->SyncSetKeyValue(keyAlloc.LastKnownGoodTimeKey(), buf, static_cast<uint16_t>(length)));
     return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR LastKnownGoodTime::StoreLastKnownGoodChipEpochTime(System::Clock::Seconds32 lastKnownGoodChipEpochTime) const
-{
-    return StoreLastKnownGoodChipEpochTime(lastKnownGoodChipEpochTime, NullOptional);
 }
 
 CHIP_ERROR LastKnownGoodTime::Init(PersistentStorageDelegate * storage)
@@ -190,7 +163,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR LastKnownGoodTime::UpdateLastKnownGoodChipEpochTime(System::Clock::Seconds32 lastKnownGoodChipEpochTime)
+CHIP_ERROR LastKnownGoodTime::UpdatePendingLastKnownGoodChipEpochTime(System::Clock::Seconds32 lastKnownGoodChipEpochTime)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     VerifyOrExit(mLastKnownGoodChipEpochTime.HasValue(), err = CHIP_ERROR_INCORRECT_STATE);
@@ -198,35 +171,22 @@ CHIP_ERROR LastKnownGoodTime::UpdateLastKnownGoodChipEpochTime(System::Clock::Se
     LogTime("New proposed Last Known Good Time: ", lastKnownGoodChipEpochTime);
     if (lastKnownGoodChipEpochTime > mLastKnownGoodChipEpochTime.Value())
     {
-        LogTime("Current Last Known Good time retained in fail-safe context, updating to ", lastKnownGoodChipEpochTime);
-        // We have a later timestamp.  Advance last known good time and store
-        // the fail-safe value.
-        SuccessOrExit(
-            err = StoreLastKnownGoodChipEpochTime(lastKnownGoodChipEpochTime, MakeOptional(mLastKnownGoodChipEpochTime.Value())));
+        LogTime("Updating pending Last Known Good Time to ", lastKnownGoodChipEpochTime);
         mLastKnownGoodChipEpochTime.SetValue(lastKnownGoodChipEpochTime);
     }
     else
     {
         ChipLogProgress(TimeService, "Retaining current Last Known Good Time");
-        // Our timestamp is not later.  Retain the existing last known good time
-        // and discard any fail-safe value in persistence.
-        SuccessOrExit(err = StoreLastKnownGoodChipEpochTime(mLastKnownGoodChipEpochTime.Value()));
     }
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(TimeService, "Failed to persist Last Known Good Time: %" CHIP_ERROR_FORMAT, err.Format());
-    }
     return err;
 }
 
-CHIP_ERROR LastKnownGoodTime::CommitLastKnownGoodChipEpochTime()
+CHIP_ERROR LastKnownGoodTime::CommitPendingLastKnownGoodChipEpochTime()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     VerifyOrExit(mLastKnownGoodChipEpochTime.HasValue(), err = CHIP_ERROR_INCORRECT_STATE);
     LogTime("Committing Last Known Good Time to storage: ", mLastKnownGoodChipEpochTime.Value());
-    // Writing with no fail-safe backup removes the fail-safe backup from
-    // storage, thus committing the new Last Known Good Time.
     SuccessOrExit(err = StoreLastKnownGoodChipEpochTime(mLastKnownGoodChipEpochTime.Value()));
 exit:
     if (err != CHIP_NO_ERROR)
@@ -236,30 +196,23 @@ exit:
     return err;
 }
 
-CHIP_ERROR LastKnownGoodTime::RevertLastKnownGoodChipEpochTime()
+CHIP_ERROR LastKnownGoodTime::RevertPendingLastKnownGoodChipEpochTime()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    System::Clock::Seconds32 lastKnownGoodChipEpochTime;
-    Optional<System::Clock::Seconds32> failSafeBackup;
+    System::Clock::Seconds32 storedLastKnownGoodChipEpochTime;
     VerifyOrExit(mLastKnownGoodChipEpochTime.HasValue(), err = CHIP_ERROR_INCORRECT_STATE);
-    LogTime("Last Known Good Time: ", mLastKnownGoodChipEpochTime.Value());
-    SuccessOrExit(err = LoadLastKnownGoodChipEpochTime(lastKnownGoodChipEpochTime, failSafeBackup));
-    if (!failSafeBackup.HasValue())
-    {
-        ChipLogProgress(TimeService, "No fail safe Last Known Good Time to revert to");
-        return CHIP_NO_ERROR; // if there's no value to revert to, we are done
-    }
-    LogTime("Fail safe Last Known Good Time: ", failSafeBackup.Value());
-    SuccessOrExit(err = StoreLastKnownGoodChipEpochTime(failSafeBackup.Value()));
-    mLastKnownGoodChipEpochTime.SetValue(failSafeBackup.Value());
+    LogTime("Pending Last Known Good Time: ", mLastKnownGoodChipEpochTime.Value());
+    SuccessOrExit(err = LoadLastKnownGoodChipEpochTime(storedLastKnownGoodChipEpochTime));
+    LogTime("Previous Last Known Good Time: ", storedLastKnownGoodChipEpochTime);
+    mLastKnownGoodChipEpochTime.SetValue(storedLastKnownGoodChipEpochTime);
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(TimeService, "Failed to persist Last Known Good Time: %" CHIP_ERROR_FORMAT, err.Format());
+        ChipLogError(TimeService, "Failed to revert Last Known Good Time: %" CHIP_ERROR_FORMAT, err.Format());
     }
     else
     {
-        ChipLogProgress(TimeService, "Reverted Last Known Good Time to fail safe value");
+        ChipLogProgress(TimeService, "Reverted Last Known Good Time to previous value");
     }
     return err;
 }

--- a/src/credentials/LastKnownGoodTime.h
+++ b/src/credentials/LastKnownGoodTime.h
@@ -80,25 +80,21 @@ public:
 
     /**
      * Update the Last Known Good Time to the later of the current value and
-     * the passed value and persist to storage.  If the value is changed, also
-     * store the current value for fail-safe recovery.
-     *
-     * We can only support storage of a single fail-safe recovery value, so
-     * for nodes and fabric additions where fail-safe recovery is required, this
-     * should only be called from within a fail-safe context.
+     * the passed value and store in RAM.  This does not persist the value.
+     * Persist only happens if CommitPendingLastKnownGoodChipEpochTime is
+     * called.
      *
      * @param lastKnownGoodChipEpochTime Last Known Good Time in seconds since CHIP epoch
      * @return CHIP_NO_ERROR on success, else an appopriate CHIP_ERROR
      */
-    CHIP_ERROR UpdateLastKnownGoodChipEpochTime(System::Clock::Seconds32 lastKnownGoodChipEpochTime);
+    CHIP_ERROR UpdatePendingLastKnownGoodChipEpochTime(System::Clock::Seconds32 lastKnownGoodChipEpochTime);
 
     /*
-     * Commit the Last Known Good Time by deleting the fail-safe backup from
-     * storage.
+     * Commit the pending Last Known Good Time in RAM to storage.
      *
      * @return CHIP_NO_ERROR on success, else an appopriate CHIP_ERROR
      */
-    CHIP_ERROR CommitLastKnownGoodChipEpochTime();
+    CHIP_ERROR CommitPendingLastKnownGoodChipEpochTime();
 
     /*
      * Revert the Last Known Good Time to the fail-safe backup value in
@@ -106,7 +102,7 @@ public:
      *
      * @return CHIP_NO_ERROR on success, else an appopriate CHIP_ERROR
      */
-    CHIP_ERROR RevertLastKnownGoodChipEpochTime();
+    CHIP_ERROR RevertPendingLastKnownGoodChipEpochTime();
 
 private:
     static constexpr size_t LastKnownGoodTimeTLVMaxSize()
@@ -125,18 +121,6 @@ private:
     void LogTime(const char * msg, System::Clock::Seconds32 chipEpochTime);
 
     /**
-     * Load the Last Known Good Time from storage and, optionally, a fail-safe
-     * value to fall back to if any exists.
-     *
-     * @param lastKnownGoodChipEpochTime (out) Last Known Good Time as seconds from CHIP epoch
-     * @param failSafeBackup (out) an optional Fail Safe context last known good time value to fall back to, also in seconds from
-     * CHIP epoch from CHIP epoch
-     * @return CHIP_NO_ERROR on success, else an appropriate CHIP_ERROR
-     */
-    CHIP_ERROR LoadLastKnownGoodChipEpochTime(System::Clock::Seconds32 & lastKnownGoodChipEpochTime,
-                                              Optional<System::Clock::Seconds32> & failSafeBackup) const;
-
-    /**
      * Load the Last Known Good Time from storage.
      *
      * @param lastKnownGoodChipEpochTime (out) Last Known Good Time as seconds from CHIP epoch
@@ -145,19 +129,7 @@ private:
     CHIP_ERROR LoadLastKnownGoodChipEpochTime(System::Clock::Seconds32 & lastKnownGoodChipEpochTime) const;
 
     /**
-     * Store the Last Known Good Time to storage, and optionally, a fail-safe
-     * value to fall back to if the fail safe timer expires.
-     *
-     * @param lastKnownGoodChipEpochTime Last Known Good Time as seconds from CHIP epoch
-     * @param failSafeBackup fail safe backup of the previous Last Known Good Time
-     * @return CHIP_NO_ERROR on success, else an appropriate CHIP_ERROR
-     */
-    CHIP_ERROR StoreLastKnownGoodChipEpochTime(System::Clock::Seconds32 lastKnownGoodChipEpochTime,
-                                               const Optional<System::Clock::Seconds32> & failSafeBackup) const;
-
-    /**
-     * Store the Last Known Good Time to storage.  This overload also clears
-     * the fail safe Last Known Good Time from storage.
+     * Store the Last Known Good Time to storage.
      *
      * @param lastKnownGoodChipEpochTime Last Known Good Time as seconds from CHIP epoch
      * @return CHIP_NO_ERROR on success, else an appropriate CHIP_ERROR


### PR DESCRIPTION
#### Problem
Last known Good Time commit / revert strategy does not align to new fabric commit / revert strategy, which stages pending fabric info in RAM and only persists at commit.

#### Change overview
Align Last Known Good Time commit / revert strategy to new fabric commit / revert strategy, holding pending Last Known Good Time in RAM and only persisting at commit.

#### Testing
TestFabricTable was updated for compatibility with the new approach, but retaining similar test coverage as before. The updated test passes.