### PR TITLE
Fix ninja dependency issue.

### DIFF
--- a/src/app/chip_data_model.gni
+++ b/src/app/chip_data_model.gni
@@ -212,6 +212,8 @@ template("chip_data_model") {
       defines = []
     }
 
+    time_synchronization_cluster_included = false
+
     foreach(cluster, _cluster_sources) {
       if (cluster == "door-lock-server") {
         sources += [
@@ -272,10 +274,9 @@ template("chip_data_model") {
           "${_app_root}/clusters/${cluster}/DefaultTimeSyncDelegate.cpp",
           "${_app_root}/clusters/${cluster}/TimeSyncDataProvider.cpp",
         ]
-        defines += [
-          "TIME_SYNC_ENABLE_TSC_FEATURE=${time_sync_enable_tsc_feature}",
-          "TIME_SYNCHRONIZATION_CLUSTER_INCLUDED=1",
-        ]
+        defines +=
+            [ "TIME_SYNC_ENABLE_TSC_FEATURE=${time_sync_enable_tsc_feature}" ]
+        time_synchronization_cluster_included = true
       } else if (cluster == "scenes-server") {
         sources += [
           "${_app_root}/clusters/${cluster}/${cluster}.cpp",
@@ -335,6 +336,8 @@ template("chip_data_model") {
         sources += [ "${_app_root}/clusters/${cluster}/${cluster}.cpp" ]
       }
     }
+
+    defines += [ "TIME_SYNCHRONIZATION_CLUSTER_INCLUDED=${time_synchronization_cluster_included}" ]
 
     if (!defined(public_deps)) {
       public_deps = []

--- a/src/app/clusters/general-diagnostics-server/general-diagnostics-server.cpp
+++ b/src/app/clusters/general-diagnostics-server/general-diagnostics-server.cpp
@@ -17,8 +17,13 @@
 
 #include "general-diagnostics-server.h"
 
-#ifdef TIME_SYNCHRONIZATION_CLUSTER_INCLUDED
-#include "app/clusters/time-synchronization-server/time-synchronization-server.h"
+#if TIME_SYNCHRONIZATION_CLUSTER_INCLUDED
+// nogncheck because gn dependency checking does not understand conditional
+// includes and claims that time-synchronization-server.h is not in any
+// dependency in situations where TIME_SYNCHRONIZATION_CLUSTER_INCLUDED is
+// false.
+#include "app/clusters/time-synchronization-server/time-synchronization-server.h" // nogncheck
+
 #endif // TIME_SYNCHRONIZATION_CLUSTER_INCLUDED
 
 #include "app/server/Server.h"
@@ -398,7 +403,7 @@ bool emberAfGeneralDiagnosticsClusterTimeSnapshotCallback(CommandHandler * comma
 
     System::Clock::Microseconds64 posix_time_us{ 0 };
 
-#ifdef TIME_SYNCHRONIZATION_CLUSTER_INCLUDED
+#if TIME_SYNCHRONIZATION_CLUSTER_INCLUDED
 #ifdef ZCL_USING_TIME_SYNCHRONIZATION_CLUSTER_SERVER
     bool time_is_synced = false;
     using Clusters::TimeSynchronization::GranularityEnum;


### PR DESCRIPTION
The real fix is the nogncheck annotation and the comment explaining why it's there.

The other changes are to ensure that we always set TIME_SYNCHRONIZATION_CLUSTER_INCLUDED in chip_data_model.gni and check for it using #if, not #ifdef.  That should catch issues with build systems that are not setting it at all, as long as -Wundef is being used there, and lead to that being fixed.
